### PR TITLE
feat: add tracking code to website head element

### DIFF
--- a/web/themes/interledger/templates/html.html.twig
+++ b/web/themes/interledger/templates/html.html.twig
@@ -13,6 +13,7 @@
     <title>{{ head_title|safe_join(' | ') }}</title>
     <css-placeholder token="{{ placeholder_token }}">
     <js-placeholder token="{{ placeholder_token }}">
+    <script defer src="https://ilf-site-analytics.netlify.app/script.js" data-website-id="50d81dd1-bd02-4f82-8a55-34a09ccbbbd9"></script>
   </head>
   <body{{ attributes.addClass(body_classes) }}>
     <a href="#main-content" class="visually-hidden focusable skip-link">


### PR DESCRIPTION
Closes #17 

This PR adds the tracking code from our self-hosted instance of Umami Analytics (see https://github.com/interledger/site-analytics) to the head of the website.