### PR TITLE
fix: add margin to cta when hero type is photography

### DIFF
--- a/web/themes/interledger/css/styles.css
+++ b/web/themes/interledger/css/styles.css
@@ -1366,6 +1366,10 @@ button[aria-expanded="true"] + .faq__ans-wrapper {
   border-radius: var(--border-radius);
 }
 
+.hero--photography .hero__cta {
+  margin-inline-start: var(--space-m);
+}
+
 .hero__caption {
   position: absolute;
   right: 0;


### PR DESCRIPTION
Originally, the hero designs never had CTAs on them, and so the styling did not take into account how an additional CTA would look. Turns out it does need a bit of margin to make it consistent.