### PR TITLE
Sj/newsletter subscription updates

### DIFF
--- a/web/themes/interledger/css/styles.css
+++ b/web/themes/interledger/css/styles.css
@@ -1231,7 +1231,12 @@ section {
 
 .form.form__body {
   gap: var(--space-l);
-  text-align: justify;
+}
+
+.form ul {
+  list-style-position: inside;
+  padding-left: 0;
+  margin-left: 0;
 }
 
 .form__image {

--- a/web/themes/interledger/css/styles.css
+++ b/web/themes/interledger/css/styles.css
@@ -1258,6 +1258,10 @@ section {
 }
 
 @media (max-width: 768px) {
+  .form {
+    margin: 0 var(--step-1);
+  }
+
   .form__body {
     flex-direction: column;
     align-items: center;

--- a/web/themes/interledger/css/styles.css
+++ b/web/themes/interledger/css/styles.css
@@ -270,12 +270,6 @@ figcaption {
   font-size: var(--step--1);
 }
 
-.subscribe-btn.button {
-  box-shadow: none;
-  border: 1px solid var(--color-primary-fallback);
-  border: 1px solid var(--color-primary);
-}
-
 .button::before {
   content: "";
   display: block;
@@ -292,6 +286,13 @@ figcaption {
   box-shadow: -9px 5px 4px -16px rgba(232, 232, 232, 0.5), 0px 5px 12px -16px #c6c6c6, 0px 4px 5px rgba(0, 0, 0, 0.02),
     0px 8px 5px rgba(0, 0, 0, 0.11), 0px 0px 0px 2px var(--color-btn-outline-pressed),
     inset 10px -16px 28px -16px rgba(198, 198, 198, 0.28);
+}
+
+.subscribe-btn, .subscribe-btn::before {
+  box-shadow: none;
+  border: 1px solid var(--color-primary-fallback);
+  border: 1px solid var(--color-primary);
+  text-decoration: none;
 }
 
 input:not([type="submit"]):not([type="file"]),
@@ -706,7 +707,7 @@ section {
   }
 }
 
-.site-footer.button {
+.site-footer .subscribe-btn {
   display: flex;
   justify-content: center;
   align-items: center;
@@ -714,6 +715,8 @@ section {
   box-shadow: none;
   border: 1px solid var(--color-primary-fallback);
   border: 1px solid var(--color-primary);
+  max-width: 10em;
+  margin-inline: auto;
 }
 
 .mailing-list h3 {
@@ -1220,7 +1223,15 @@ section {
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  gap: var(--space-m);
+}
+
+.form.form__header {
+  gap: var(--space-s);
+}
+
+.form.form__body {
+  gap: var(--space-l);
+  text-align: justify;
 }
 
 .form__image {
@@ -1671,16 +1682,6 @@ button[aria-expanded="true"] + .faq__ans-wrapper {
 
 .text__body p + ul {
   margin-block-start: var(--space-xs);
-}
-
-.text__body label[for="mce-EMAIL"] {
-  color: var(--color-primary-fallback);
-  color: var(--color-primary);
-  cursor: pointer;
-}
-
-.text__body label[for="mce-EMAIL"]:hover {
-  text-decoration: underline;
 }
 
 @media screen and (max-width: 799px) {

--- a/web/themes/interledger/css/styles.css
+++ b/web/themes/interledger/css/styles.css
@@ -270,6 +270,12 @@ figcaption {
   font-size: var(--step--1);
 }
 
+.subscribe-btn.button {
+  box-shadow: none;
+  border: 1px solid var(--color-primary-fallback);
+  border: 1px solid var(--color-primary);
+}
+
 .button::before {
   content: "";
   display: block;
@@ -700,25 +706,18 @@ section {
   }
 }
 
-.site-footer form {
+.site-footer.button {
   display: flex;
   justify-content: center;
   align-items: center;
   margin-block-end: var(--space-s);
-}
-
-.site-footer form input[type="email"] {
-  border-start-end-radius: 0px;
-  border-end-end-radius: 0px;
-  border-inline-end-color: transparent;
-}
-
-.site-footer form input[type="submit"] {
-  border-start-start-radius: 0px;
-  border-end-start-radius: 0px;
   box-shadow: none;
   border: 1px solid var(--color-primary-fallback);
   border: 1px solid var(--color-primary);
+}
+
+.mailing-list h3 {
+  margin-block-end: var(--space-2xs);
 }
 
 .social-links h3 {
@@ -1216,25 +1215,37 @@ section {
   filter: initial;
 }
 
-/* CTA stripe content type styles */
-.cta--mailing-list {
-  border-radius: var(--border-radius);
-  text-align: center;
+/* The form block */
+.form {
   display: flex;
-  align-items: center;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-m);
+}
+
+.form__image {
+  max-width: 4em;
+  margin-bottom: var(--space-3xs);
+}
+
+.form__body form {
+  display: flex;
   flex-direction: column;
-  gap: var(--space-3xs);
-  padding: var(--space-s);
-}
-
-.cta--mailing-list img {
-  max-width: 5em;
-}
-
-.cta--mailing-list form {
-  display: flex;
   align-items: center;
-  gap: var(--space-2xs);
+  gap: var(--space-xs);
+  border-radius: var(--border-radius);
+}
+
+.form .form__input input {
+  padding: var(--space-xs) var(--space-s);
+  font-size: var(--step-0);
+}
+
+@media (max-width: 768px) {
+  .form__body {
+    flex-direction: column;
+    align-items: center;
+  }
 }
 
 /* FAQ content type styles */

--- a/web/themes/interledger/templates/node--form-block.html.twig
+++ b/web/themes/interledger/templates/node--form-block.html.twig
@@ -24,9 +24,11 @@
 
 <section>
   <div class="form form__body content-wrapper">
-    <div class="text-wrapper text--body-right">
-      <div class="text__body">{{ content.field_form_text.0|raw }}</div>
-    </div>
+    {% if content.field_form_text.0 is not empty %}
+      <div class="text-wrapper text--body-right">
+        <div class="text__body">{{ content.field_form_text.0|raw }}</div>
+      </div>
+    {% endif %}
 
     <div class="cta--{{ content.field_cta_type.0|render|lower|replace({' ':'-'}) }} node--{{ node.id }}">
       <form action="{{ node.field_cta_link.0.uri }}" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_self" novalidate="" data-umami-event="{{ node.field_umami_event.0.value|raw }}">

--- a/web/themes/interledger/templates/node--form-block.html.twig
+++ b/web/themes/interledger/templates/node--form-block.html.twig
@@ -30,7 +30,7 @@
     {% endif %}
 
     <div class="cta--{{ content.field_cta_type.0|render|lower|replace({' ':'-'}) }} node--{{ node.id }}">
-      <form action="{{ node.field_cta_link.0.uri }}" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_self" novalidate="" data-umami-event="{{ node.field_umami_event.0.value|raw }}">
+      <form action="{{ node.field_cta_link.0.uri }}" method="post" id="{{ content.field_form_id.0|raw }}" name="{{ content.field_form_name.0|raw }}" class="validate" target="_self" novalidate="" data-umami-event="{{ node.field_umami_event.0.value|raw }}">
 
         {% for form_field in content.field_input_field %}
           {% if form_field['#node'] is not empty %}

--- a/web/themes/interledger/templates/node--form-block.html.twig
+++ b/web/themes/interledger/templates/node--form-block.html.twig
@@ -30,7 +30,7 @@
     {% endif %}
 
     <div class="cta--{{ content.field_cta_type.0|render|lower|replace({' ':'-'}) }} node--{{ node.id }}">
-      <form action="{{ node.field_cta_link.0.uri }}" method="post" id="{{ content.field_form_id.0|raw }}" name="{{ content.field_form_name.0|raw }}" class="validate" target="_self" novalidate="" data-umami-event="{{ node.field_umami_event.0.value|raw }}">
+      <form action="{{ node.field_form_link.0.uri }}" method="post" id="{{ content.field_form_id.0|raw }}" name="{{ content.field_form_name.0|raw }}" class="validate" target="_self" novalidate="" data-umami-event="{{ node.field_umami_event.0.value|raw }}">
 
         {% for form_field in content.field_input_field %}
           {% if form_field['#node'] is not empty %}

--- a/web/themes/interledger/templates/node--form-block.html.twig
+++ b/web/themes/interledger/templates/node--form-block.html.twig
@@ -1,0 +1,65 @@
+{% set svgUrl = content.field_cta_image[0]['#media'].field_media_svg.entity.uri.value|file_url %}
+{% set svgAlt = content.field_cta_image[0]['#media'].field_media_svg.alt %}
+
+{% set imageUrl = null %}
+{% if content.field_cta_image[0]['#media'].field_media_image.entity.uri.value is not empty %}
+  {% set imageUrl = file_url(content.field_cta_image[0]['#media'].field_media_image.entity.uri.value | image_style('original_webp')) %}
+{% endif %}
+{% set imageAlt = content.field_cta_image[0]['#media'].field_media_image.alt|default('') %}
+
+
+<section>
+  <div class="form form__header content-wrapper">
+    <div class="text-wrapper text--body-right">
+      <h2>Subscribe to the Interledger Newsletter</h2>
+    </div>
+
+    {% if svgUrl|default(null) %}
+      <img src="{{ svgUrl }}" alt="{{ svgAlt }}" class="form__image">
+    {% elseif imageUrl|default(null) %}
+      <img src="{{ imageUrl }}" alt="{{ imageAlt }}" class="form__image">
+    {% endif %}
+  </div>
+</section>
+
+<section>
+  <div class="form form__body content-wrapper">
+    <div class="text-wrapper text--body-right">
+      <div class="text__body">{{ content.field_form_text.0|raw }}</div>
+    </div>
+
+    <div class="cta--{{ content.field_cta_type.0|render|lower|replace({' ':'-'}) }} node--{{ node.id }}">
+      <form action="{{ node.field_cta_link.0.uri }}" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_self" novalidate="" data-umami-event="{{ node.field_umami_event.0.value|raw }}">
+
+        {% for form_field in content.field_input_field %}
+          {% set fieldNode = form_field['#node'] %}
+          
+          {% if fieldNode is not empty %}
+            {% if fieldNode.field_honeypot.value %}
+              <div aria-hidden="true" style="position: absolute; left: -5000px;">
+                <input type="{{ fieldNode.field_input_type.value }}" name="{{ fieldNode.field_input_name.value }}" tabindex="{{ fieldNode.field_tab_index.value }}" value="">
+              </div>
+            {% else %}
+              <div class="form__input">
+                {% set input_type = fieldNode.field_input_type.value %}
+                {% set input_required = fieldNode.field_input_required.value ? 'required' : '' %}
+                
+                <label for="{{ fieldNode.field_input_id.value }}" class="visually-hidden">{{ fieldNode.field_input_placeholder.value }}</label>
+                <input
+                  type="{{ input_type }}" 
+                  class="{{ fieldNode.field_input_class.value }}" 
+                  id="{{ fieldNode.field_input_id.value }}" 
+                  name="{{ fieldNode.field_input_name.value }}" 
+                  placeholder="{{ fieldNode.field_input_placeholder.value }}" 
+                  {{ input_required }}
+                  tabindex="{{ fieldNode.field_tab_index.value }}"
+                  value="{{ fieldNode.field_input_value.value }}">
+              </div>
+            {% endif %}
+          {% endif %}
+        {% endfor %}
+
+      </form>
+    </div>
+  </div>
+</section>

--- a/web/themes/interledger/templates/node--form-block.html.twig
+++ b/web/themes/interledger/templates/node--form-block.html.twig
@@ -1,11 +1,11 @@
-{% set svgUrl = content.field_cta_image[0]['#media'].field_media_svg.entity.uri.value|file_url %}
-{% set svgAlt = content.field_cta_image[0]['#media'].field_media_svg.alt %}
+{% set svgUrl = content.field_form_heading_image[0]['#media'].field_media_svg.entity.uri.value|file_url %}
+{% set svgAlt = content.field_form_heading_image[0]['#media'].field_media_svg.alt %}
 
 {% set imageUrl = null %}
-{% if content.field_cta_image[0]['#media'].field_media_image.entity.uri.value is not empty %}
-  {% set imageUrl = file_url(content.field_cta_image[0]['#media'].field_media_image.entity.uri.value | image_style('original_webp')) %}
+{% if content.field_form_heading_image[0]['#media'].field_media_image.entity.uri.value is not empty %}
+  {% set imageUrl = file_url(content.field_form_heading_image[0]['#media'].field_media_image.entity.uri.value | image_style('original_webp')) %}
 {% endif %}
-{% set imageAlt = content.field_cta_image[0]['#media'].field_media_image.alt|default('') %}
+{% set imageAlt = content.field_form_heading_image[0]['#media'].field_media_image.alt|default('') %}
 
 <section>
   <div class="form form__header content-wrapper">

--- a/web/themes/interledger/templates/node--form-block.html.twig
+++ b/web/themes/interledger/templates/node--form-block.html.twig
@@ -7,11 +7,10 @@
 {% endif %}
 {% set imageAlt = content.field_cta_image[0]['#media'].field_media_image.alt|default('') %}
 
-
 <section>
   <div class="form form__header content-wrapper">
     <div class="text-wrapper text--body-right">
-      <h2>Subscribe to the Interledger Newsletter</h2>
+      <h2>{{ content.field_form_heading.0|raw }}</h2>
     </div>
 
     {% if svgUrl|default(null) %}
@@ -34,30 +33,8 @@
       <form action="{{ node.field_cta_link.0.uri }}" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_self" novalidate="" data-umami-event="{{ node.field_umami_event.0.value|raw }}">
 
         {% for form_field in content.field_input_field %}
-          {% set fieldNode = form_field['#node'] %}
-          
-          {% if fieldNode is not empty %}
-            {% if fieldNode.field_honeypot.value %}
-              <div aria-hidden="true" style="position: absolute; left: -5000px;">
-                <input type="{{ fieldNode.field_input_type.value }}" name="{{ fieldNode.field_input_name.value }}" tabindex="{{ fieldNode.field_tab_index.value }}" value="">
-              </div>
-            {% else %}
-              <div class="form__input">
-                {% set input_type = fieldNode.field_input_type.value %}
-                {% set input_required = fieldNode.field_input_required.value ? 'required' : '' %}
-                
-                <label for="{{ fieldNode.field_input_id.value }}" class="visually-hidden">{{ fieldNode.field_input_placeholder.value }}</label>
-                <input
-                  type="{{ input_type }}" 
-                  class="{{ fieldNode.field_input_class.value }}" 
-                  id="{{ fieldNode.field_input_id.value }}" 
-                  name="{{ fieldNode.field_input_name.value }}" 
-                  placeholder="{{ fieldNode.field_input_placeholder.value }}" 
-                  {{ input_required }}
-                  tabindex="{{ fieldNode.field_tab_index.value }}"
-                  value="{{ fieldNode.field_input_value.value }}">
-              </div>
-            {% endif %}
+          {% if form_field['#node'] is not empty %}
+            {{ form_field }}
           {% endif %}
         {% endfor %}
 

--- a/web/themes/interledger/templates/node--form-field.html.twig
+++ b/web/themes/interledger/templates/node--form-field.html.twig
@@ -1,6 +1,6 @@
 {% if node.field_honeypot[0].value %}
     <div aria-hidden="true" style="position: absolute; left: -5000px;">
-    <input type="{{ node.field_input_type[0].value }}" name="{{ node.field_input_name[0].value }}" tabindex="{{ node.field_tab_index[0].value }}" value="">
+    <input type="{{ node.field_input_type[0].value }}" name="{{ node.field_input_name[0].value }}" tabindex="{{ node.field_input_tabindex[0].value }}" value="">
     </div>
 {% else %}
     <div class="form__input">
@@ -15,7 +15,7 @@
         name="{{ node.field_input_name[0].value }}" 
         placeholder="{{ node.field_input_placeholder[0].value }}" 
         {{ input_required }}
-        tabindex="{{ node.field_tab_index[0].value }}"
+        tabindex="{{ node.field_input_tabindex[0].value }}"
         value="{{ node.field_input_value[0].value }}">
     </div>
 {% endif %}

--- a/web/themes/interledger/templates/node--form-field.html.twig
+++ b/web/themes/interledger/templates/node--form-field.html.twig
@@ -1,0 +1,21 @@
+{% if node.field_honeypot[0].value %}
+    <div aria-hidden="true" style="position: absolute; left: -5000px;">
+    <input type="{{ node.field_input_type[0].value }}" name="{{ node.field_input_name[0].value }}" tabindex="{{ node.field_tab_index[0].value }}" value="">
+    </div>
+{% else %}
+    <div class="form__input">
+    {% set input_type = node.field_input_type[0].value %}
+    {% set input_required = node.field_input_required[0].value ? 'required' : '' %}
+    
+    <label for="{{ node.field_input_id[0].value }}" class="visually-hidden">{{ node.field_input_placeholder[0].value }}</label>
+    <input
+        type="{{ input_type }}" 
+        class="{{ node.field_input_class[0].value }}" 
+        id="{{ node.field_input_id[0].value }}" 
+        name="{{ node.field_input_name[0].value }}" 
+        placeholder="{{ node.field_input_placeholder[0].value }}" 
+        {{ input_required }}
+        tabindex="{{ node.field_tab_index[0].value }}"
+        value="{{ node.field_input_value[0].value }}">
+    </div>
+{% endif %}

--- a/web/themes/interledger/templates/partials/footer.html.twig
+++ b/web/themes/interledger/templates/partials/footer.html.twig
@@ -2,16 +2,9 @@
   <div class="connect-wrapper">
     <div class="mailing-list">
       <h3>Join our mailing list</h3>
-      <form action="https://interledger.us1.list-manage.com/subscribe/post?u=9ced7a326efbb158ae84d30cc&amp;id=7466ff6b0c&amp;f_id=0066e3e5f0" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_self" novalidate="">
-        <div class="mc-field-group">
-          <label for="mce-EMAIL" class="visually-hidden">Email Address</label>
-          <input type="email" name="EMAIL" class="required email" id="mce-EMAIL" required="" value="" placeholder="Email address">
-        </div>
-        <div aria-hidden="true" style="position: absolute; left: -5000px;">
-          <input type="text" name="b_9ced7a326efbb158ae84d30cc_7466ff6b0c" tabindex="-1" value="">
-        </div>
-        <input type="submit" name="subscribe" id="mc-embedded-subscribe" class="button" value="Subscribe">
-      </form>
+      <a class="button subscribe-btn" href="/subscribe"">
+        Subscribe
+      </a>
     </div>
     <div class="social-links">
       <h3>Connect with us</h3>


### PR DESCRIPTION
Alongside this code, on the Drupal instance:

- Create a Form Block and Form field input types (see images for overview)
- Create a form block content entry with form field content entries.
- Create a /subscribe foundation page which includes the form block content entry.
- On the summit home page add a highlight text ''Can't join us in Cape Town?"
- On the summit home page add a text block with link to subscribe. This text block needs to be HTML and include a script tag to manually fire an umami event when the summit home page loads with the LinkedIn campaign params in the URL)
- Remove the mailing list option on the CTA stripe since we've moved to a form based approach (including those style and template entries).
- Style the footer to include a subscribe button instead of a subscribe form. The button now points to the subscribe page (needs an umami event on click)

TODO

- [ ] style embedded form validation error page on Mailchimp if possible (when users get validation errors they get taken to the ugly page...)
- [ ] style email confirmation step page on Mailchimp if possible.
- [ ] style confirm humanity page on Mailchimp if possible.
- [ ] Create Umami filter report that shows how clicks on the campagin that go to summit home page convert into clicks on the subscription link.

Screenshots for context:
![image](https://github.com/user-attachments/assets/9c7846c5-b78a-4b25-aa81-7c9805a82d92)
![image](https://github.com/user-attachments/assets/80b0441b-e41a-4ec5-a910-22c06ad41dd2)

