### PR TITLE
feat: make cards optionally clickable and style for hackathon-wrapper

### DIFF
--- a/web/themes/interledger/css/styles.css
+++ b/web/themes/interledger/css/styles.css
@@ -78,6 +78,7 @@
   --color-admin-bg: var(--color-white);
   --color-header-bg: var(--color-white);
   --color-card-bg: var(--color-white);
+  --color-card-outline: rgba(25, 25, 25, 0.3);
   --color-btn-outline: rgba(25, 25, 25, 0.45);
   --color-btn-outline-pressed: rgba(25, 25, 25, 0.85);
 
@@ -128,6 +129,7 @@
   --color-admin-bg: var(--color-black);
   --color-header-bg: var(--color-black);
   --color-card-bg: var(--color-black);
+  --color-card-outline: rgba(255, 255, 255, 0.3);
   --color-frost: rgba(255, 255, 255, 0.5);
 }
 
@@ -1185,6 +1187,39 @@ section {
   transform: translateX(0.5em);
 }
 
+.clickable-card {
+  background-color: var(--color-card-bg);
+  transition: box-shadow 0.3s ease;
+}
+
+.clickable-card:hover {
+  box-shadow: inset 0 0 10px var(--color-card-outline);
+}
+
+.clickable-card a {
+  text-decoration: none;
+  color: inherit;
+}
+
+.clickable-card:hover a {
+  cursor: pointer;
+  text-decoration: none;
+  color: inherit;
+}
+
+.clickable-card a h3 {
+  color: var(--color-primary-fallback);
+  color: var(--color-primary);
+}
+
+.clickable-card:hover a h3 {
+  text-decoration: underline;
+}
+
+.clickable-card .card-content-wrapper {
+  background-color:  transparent;
+}
+
 /* CTA button content type styles */
 .cta--btn__link {
   border-radius: 10em;
@@ -1768,6 +1803,13 @@ button[aria-expanded="true"] + .faq__ans-wrapper {
 
 /* Art block styling */
 .art-wrapper {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(12em, 1fr));
+  gap: var(--space-s);
+}
+
+/* Hackathon block styling */
+.hackathon-wrapper {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(12em, 1fr));
   gap: var(--space-s);

--- a/web/themes/interledger/templates/node--card.html.twig
+++ b/web/themes/interledger/templates/node--card.html.twig
@@ -1,31 +1,61 @@
 {% set renderCaption = node.field_card_caption.0.value|raw %}
-
-<div class="card node--{{ node.id }} {{ (renderCaption) ? 'card--has-txt' : 'card--no-txt' }}">
-  <div class="card__media">  
-    {{ content.field_card_image }}
-  </div>
-  {% if renderCaption %}
-  <div class="card-content-wrapper">
-    {% if node.field_card_title is not empty %}
-    <h3 class="card__title">{{ node.field_card_title.0.value|raw }}</h3>
-    {% endif %}
-    {% if node.field_card_blurb is not empty %}
-    <p class="card__desc">{{ node.field_card_blurb.0.value|raw }}<p>
-    {% endif %}
-    {% if node.field_card_link is not empty %}
-      {% if node.field_card_link.0.url.external %}
-      <a class="card__link" href="{{ node.field_card_link.uri }}">
-        {{ node.field_card_link.title }}
-      </a>
-      {% else %}
-      <a class="card__link" href="{{ path(node.field_card_link.0.url.routeName, node.field_card_link.0.url.routeParameters) }}">
-        {{ node.field_card_link.title }}
-      </a>
-      {% endif %}
-    {% endif %}
-  </div>
+{% set isClickableCard = node.field_card_link is not empty and node.field_card_link.title is empty %}
+{% set href = '' %}
+{% if node.field_card_link is not empty %}
+  {% if node.field_card_link.0.url.external %}
+    {% set href = node.field_card_link.uri %}
+  {% else %}
+    {% set href = path(node.field_card_link.0.url.routeName, node.field_card_link.0.url.routeParameters) %}
   {% endif %}
-</div>
+{% endif %}
 
-
-
+{% if isClickableCard %}
+  <div class="clickable-card card node--{{ node.id }} {{ (renderCaption) ? 'card--has-txt' : 'card--no-txt' }}">
+    <a href="{{ node.field_card_link.uri }}">
+      {% if content.field_card_image[0]['#media'] is defined %}
+        <div class="card__media">  
+          {{ content.field_card_image }}
+        </div>
+      {% endif %}
+      {% if renderCaption %}
+      <div class="card-content-wrapper">
+        {% if node.field_card_title is not empty %}
+        <h3 class="card__title">{{ node.field_card_title.0.value|raw }}</h3>
+        {% endif %}
+        {% if node.field_card_blurb is not empty %}
+        <p class="card__desc">{{ node.field_card_blurb.0.value|raw }}<p>
+        {% endif %}
+      </div>
+      {% endif %}
+    </a>
+  </div>
+{% else %}
+  <div class="card node--{{ node.id }} {{ (renderCaption) ? 'card--has-txt' : 'card--no-txt' }}">
+    {% if content.field_card_image[0]['#media'] is defined %}
+      <div class="card__media">  
+        {{ content.field_card_image }}
+      </div>
+    {% endif %}
+    {% if renderCaption %}
+    <div class="card-content-wrapper">
+      {% if node.field_card_title is not empty %}
+      <h3 class="card__title">{{ node.field_card_title.0.value|raw }}</h3>
+      {% endif %}
+      {% if node.field_card_blurb is not empty %}
+      <p class="card__desc">{{ node.field_card_blurb.0.value|raw }}<p>
+      {% endif %}
+      {% if node.field_card_link is not empty %}
+        {% if node.field_card_link.0.url.external %}
+        <a class="card__link" href="{{ node.field_card_link.uri }}">
+          {{ node.field_card_link.title }}
+        </a>
+        {% else %}
+        <a class="card__link" href="{{ path(node.field_card_link.0.url.routeName, node.field_card_link.0.url.routeParameters) }}">
+          {{ node.field_card_link.title }}
+        </a>
+        {% endif %}
+      {% endif %}
+    </div>
+    {% endif %}
+  </div>
+{% endif %}

--- a/web/themes/interledger/templates/views-view--cards--op-resources.html.twig
+++ b/web/themes/interledger/templates/views-view--cards--op-resources.html.twig
@@ -1,0 +1,3 @@
+<div class="content-wrapper hackathon-wrapper">
+  {{ rows }}
+</div>

--- a/web/themes/interledger/templates/views-view--hackathon-cards-block.html.twig
+++ b/web/themes/interledger/templates/views-view--hackathon-cards-block.html.twig
@@ -1,0 +1,3 @@
+<div class="content-wrapper hackathon-wrapper">
+  {{ rows }}
+</div>


### PR DESCRIPTION
The hackathon landing page needs clickable card components that link to all the different resource sections. 

This PR edits the card template files so that when a link is present but without link text it makes the entire card clickable instead.