### PR TITLE
Fix incorrect card link logic in template

### DIFF
--- a/web/themes/interledger/templates/node--card.html.twig
+++ b/web/themes/interledger/templates/node--card.html.twig
@@ -11,7 +11,7 @@
 
 {% if isClickableCard %}
   <div class="clickable-card card node--{{ node.id }} {{ (renderCaption) ? 'card--has-txt' : 'card--no-txt' }}">
-    <a href="{{ node.field_card_link.uri }}">
+    <a href="{{ href }}">
       {% if content.field_card_image[0]['#media'] is defined %}
         <div class="card__media">  
           {{ content.field_card_image }}
@@ -44,17 +44,9 @@
       {% if node.field_card_blurb is not empty %}
       <p class="card__desc">{{ node.field_card_blurb.0.value|raw }}<p>
       {% endif %}
-      {% if node.field_card_link is not empty %}
-        {% if node.field_card_link.0.url.external %}
-        <a class="card__link" href="{{ node.field_card_link.uri }}">
-          {{ node.field_card_link.title }}
-        </a>
-        {% else %}
-        <a class="card__link" href="{{ path(node.field_card_link.0.url.routeName, node.field_card_link.0.url.routeParameters) }}">
-          {{ node.field_card_link.title }}
-        </a>
-        {% endif %}
-      {% endif %}
+      <a class="card__link" href="{{ href }}">
+        {{ node.field_card_link.title }}
+      </a>
     </div>
     {% endif %}
   </div>


### PR DESCRIPTION
This PR fixes the card node template because the way links are implemented in the template are incorrect. See comments for details.