### PR TITLE
chore: widened screen breaks for the longer Spanish menu

### DIFF
--- a/web/themes/interledger/css/header.css
+++ b/web/themes/interledger/css/header.css
@@ -8,14 +8,14 @@
   box-shadow: var(--box-shadow);
 }
 
-@media screen and (min-width: 1060px) {
+@media screen and (min-width: 1160px) {
   .region-header {
     display: flex;
     align-items: center;
   }
 }
 
-@media screen and (max-width: 1059px) {
+@media screen and (max-width: 1159px) {
   .language-switcher-language-url {
     position: absolute;
     top: 25px;

--- a/web/themes/interledger/css/navigation.css
+++ b/web/themes/interledger/css/navigation.css
@@ -52,13 +52,13 @@
   }
 }
 
-@media screen and (min-width: 480px) and (max-width: 1059px) {
+@media screen and (min-width: 480px) and (max-width: 1159px) {
   .site-links-wrapper {
     width: max-content;
   }
 }
 
-@media screen and (max-width: 1059px) {
+@media screen and (max-width: 1159px) {
   [data-drupal-ajax-container] {
     display: none;
   }
@@ -166,7 +166,7 @@
   }
 }
 
-@media screen and (min-width: 1060px) {
+@media screen and (min-width: 1160px) {
   .site-nav {
     display: grid;
     grid-template-columns: auto 1fr 1fr;

--- a/web/themes/interledger/js/scripts.js
+++ b/web/themes/interledger/js/scripts.js
@@ -1,6 +1,6 @@
 // Site navigation CSS classes
 const siteLinksWrapper = document.querySelector("[data-nav-wrapper]");
-const wideNavMinWidth = window.matchMedia("(min-width: 1060px)");
+const wideNavMinWidth = window.matchMedia("(min-width: 1160px)");
 handleNavDisplayStyles(wideNavMinWidth);
 wideNavMinWidth.addEventListener("change", handleNavDisplayStyles);
 


### PR DESCRIPTION
Since the Spanish menu items are longer than the English menu items, we need the screen to break to the hamburger menu sooner.