### PR TITLE
feat: add new team member listing layout

### DIFF
--- a/web/themes/interledger/css/components/team.css
+++ b/web/themes/interledger/css/components/team.css
@@ -20,16 +20,6 @@
   margin-block-start: var(--space-3xs);
 }
 
-.team-wrapper .member__socials svg {
-  height: 1em;
-  width: 1.1em;
-  transition: transform 200ms ease-in-out;
-}
-
-.team-wrapper .member__socials a:hover svg {
-  transform: scale(1.15);
-}
-
 .member {
   padding: var(--space-s);
   display: flex;
@@ -59,6 +49,16 @@
   gap: var(--space-xs);
 }
 
+.member__socials svg {
+  height: 1em;
+  width: 1.1em;
+  transition: transform 200ms ease-in-out;
+}
+
+.member__socials a:hover svg {
+  transform: scale(1.15);
+}
+
 .member__text ul {
   margin-block-start: var(--space-s);
   margin-block-end: var(--space-s);
@@ -67,4 +67,26 @@
 .member__text ul svg {
   height: 1.25em;
   width: 1.3em;
+}
+
+.profiles-wrapper h2 {
+  font-weight: 600;
+}
+
+.profiles-listing {
+  list-style: none;
+  padding: 0;
+}
+
+.member__info img {
+  max-width: 8em;
+}
+
+.member__info h2 {
+  font-size: var(--step-0);
+}
+
+.member__info p {
+  font-size: var(--step--1);
+  margin-block-end: var(--space-3xs);
 }

--- a/web/themes/interledger/templates/node--team-member--full-content-alt-layout.html.twig
+++ b/web/themes/interledger/templates/node--team-member--full-content-alt-layout.html.twig
@@ -1,0 +1,11 @@
+<section class="member node--{{ node.id }} content-wrapper">
+ <div class="member__info"> 
+    {{ content.field_photo }}
+    <h2>{{ node.field_name.0.value|raw }}</h2>
+    <p>{{ node.field_position.0.value|raw }}</p>
+    {{ content.field_social_media_links }}
+  </div>
+  <div class="member__profile">
+    {{ node.field_profile.0.value|raw }}
+  </div>
+</section>

--- a/web/themes/interledger/templates/views-view--team-members--team-profiles-block.html.twig
+++ b/web/themes/interledger/templates/views-view--team-members--team-profiles-block.html.twig
@@ -1,0 +1,4 @@
+<div class="content-wrapper profiles-wrapper">
+  {{ header }}
+  {{ rows }}
+</div>

--- a/web/themes/interledger/templates/views-view-unformatted--team-members--team-profiles-block.html.twig
+++ b/web/themes/interledger/templates/views-view-unformatted--team-members--team-profiles-block.html.twig
@@ -1,0 +1,7 @@
+<ul class="profiles-listing">
+{% for row in rows %}
+  <li{{ row.attributes.addClass(row_classes) }}>
+    {{- row.content -}}
+  </li>
+{% endfor %}
+</ul>


### PR DESCRIPTION
This PR adds the necessary templates to display a new team listing layout that includes the profiles in the listing itself, including relevant CSS updates.