### PR TITLE
chore: highlight top menu item for any corresponding sub-page

### DIFF
--- a/web/themes/interledger/css/navigation.css
+++ b/web/themes/interledger/css/navigation.css
@@ -195,7 +195,8 @@
   }
 
   .site-nav__links .is-active {
-    text-decoration-color: currentColor;
+    text-decoration: underline currentColor 2px;
+    text-underline-offset: 8px;
   }
 
   .has-submenu {

--- a/web/themes/interledger/templates/menu--main.html.twig
+++ b/web/themes/interledger/templates/menu--main.html.twig
@@ -15,6 +15,7 @@
         set classes = [
           'menu-item',
           item.is_expanded ? 'has-submenu',
+          item.in_active_trail ? 'is-active',
           'menu-item--level-' ~ (menu_level + 1)
         ]
       %}


### PR DESCRIPTION
Improved visual feedback on the top menu to show users where they are - all sub-pages highlight the top menu item

(* except for Media page in Foundation, I don't know yet why that is)