### PR TITLE
chore: set dimensions on images in Summit session 

### DIFF
--- a/web/themes/interledger/css/components/summit-talk.css
+++ b/web/themes/interledger/css/components/summit-talk.css
@@ -98,6 +98,9 @@
 
 .talks-listing img {
   max-width: 8em;
+  max-height: 8em;
+  width:200px;
+  height: 200px;
   border-radius: 50%;
   border: 2px solid var(--color-primary-fallback);
   border: 2px solid var(--color-primary);


### PR DESCRIPTION
 set dimensions on images in Summit session pages to prevent layout shift