### PR TITLE
chore: Fix summit talks view for mobile

### DIFF
--- a/web/themes/interledger/css/components/summit-talk.css
+++ b/web/themes/interledger/css/components/summit-talk.css
@@ -74,9 +74,8 @@
 
 .talks-listing li {
   display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--space-xs);
+  gap: var(--space-m);
+  align-items: start;
   margin-block-end: var(--space-m);
 }
 
@@ -107,17 +106,17 @@
   .talk__speakers {
     flex-wrap: wrap;
   }
+
+  .talks-listing li {
+    flex-direction: column; 
+    align-items: center; 
+    gap: var(--space-xs); 
+  }
 }
 
 @media screen and (min-width: 800px) {
   .talk__speakers {
     min-width: 7em;
     flex-direction: column;
-  }
-
-  .talks-listing li {
-    flex-direction: row;
-    align-items: start;
-    gap: var(--space-m);
   }
 }

--- a/web/themes/interledger/css/components/summit-talk.css
+++ b/web/themes/interledger/css/components/summit-talk.css
@@ -53,23 +53,6 @@
   gap: var(--space-m);
 }
 
-@media screen and (max-width: 799px) {
-  .talk__info {
-    flex-direction: column;
-  }
-
-  .talk__speakers {
-    flex-wrap: wrap;
-  }
-}
-
-@media screen and (min-width: 800px) {
-  .talk__speakers {
-    min-width: 7em;
-    flex-direction: column;
-  }
-}
-
 .talk__speakers {
   display: flex;
   gap: var(--space-m);
@@ -91,8 +74,9 @@
 
 .talks-listing li {
   display: flex;
-  gap: var(--space-m);
-  align-items: start;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-xs);
   margin-block-end: var(--space-m);
 }
 
@@ -113,4 +97,27 @@
 .talk__teaser p {
   font-size: var(--step--1);
   margin-block-end: var(--space-2xs);
+}
+
+@media screen and (max-width: 799px) {
+  .talk__info {
+    flex-direction: column;
+  }
+
+  .talk__speakers {
+    flex-wrap: wrap;
+  }
+}
+
+@media screen and (min-width: 800px) {
+  .talk__speakers {
+    min-width: 7em;
+    flex-direction: column;
+  }
+
+  .talks-listing li {
+    flex-direction: row;
+    align-items: start;
+    gap: var(--space-m);
+  }
 }


### PR DESCRIPTION
On summit talks page, changed the layout for the speakers and their blurbs (used to display in a two-column layout which was too squashed for a mobile view). 