### PR TITLE
chore: umami event attributes on menu items

### DIFF
--- a/web/themes/interledger/js/scripts.js
+++ b/web/themes/interledger/js/scripts.js
@@ -5,7 +5,6 @@ handleNavDisplayStyles(wideNavMinWidth);
 wideNavMinWidth.addEventListener("change", handleNavDisplayStyles);
 
 const siteNavToggle = document.getElementById("siteNavToggle");
-const siteNavLinks = document.getElementById("siteNavLinks");
 const menuIcon = document.getElementById("menuIcon");
 
 if (document.contains(siteNavToggle)) {

--- a/web/themes/interledger/templates/menu--main.html.twig
+++ b/web/themes/interledger/templates/menu--main.html.twig
@@ -22,8 +22,7 @@
       %}
       {%
         set linkAttributes = { 
-          'data-link-label': 'Site Nav - ' ~ item.title, 
-          'data-umami-event': 'Site Nav - ' ~ item.title 
+          'data-link-label': 'Site Nav - ' ~ item.title
         }
       %}
       {% if item.url.external %}

--- a/web/themes/interledger/templates/menu--summit-navigation.html.twig
+++ b/web/themes/interledger/templates/menu--summit-navigation.html.twig
@@ -20,11 +20,7 @@
         ]
       %}
       <li{{ item.attributes.addClass(classes) }}>
-        {{ link(item.title, item.url, { 
-            'data-link-label': 'Summit Nav - ' ~ item.title,  
-            'data-umami-event': 'Summit Nav - ' ~ item.title
-          }) 
-        }}
+        {{ link(item.title, item.url, { 'data-link-label': 'Summit Nav - ' ~ item.title }) }}
         {% if item.below %}
           {{ menus.menu_links(item.below, attributes, menu_level + 1) }}
         {% endif %}


### PR DESCRIPTION
* It is duplicated work that causes the script to fail and the function to end prematurely