### PR TITLE
chore: improve accessibility for cards on homepage

### DIFF
--- a/web/themes/interledger/css/components/cards.css
+++ b/web/themes/interledger/css/components/cards.css
@@ -228,10 +228,6 @@
   align-items: stretch;
 }
 
-.navigation-wrapper .card:hover {
-  box-shadow: var(--box-shadow);
-}
-
 .navigation-wrapper .card a {
   display: flex;
   flex-direction: row;
@@ -316,7 +312,7 @@
   }
 }
 
-/* Home poage CTA block styling */
+/* Home page CTA block styling */
 .homepage-cta-cards-wrapper {
   display: flex;
   flex-wrap: wrap;

--- a/web/themes/interledger/templates/node--card.html.twig
+++ b/web/themes/interledger/templates/node--card.html.twig
@@ -16,7 +16,7 @@
   <div class="clickable-card card node--{{ node.id }} {{ (renderCaption) ? 'card--has-txt' : 'card--no-txt' }}">
     <a href="{{ href }}" data-umami-event="{{umamiEvent}}">
       {% if content.field_card_image[0]['#media'] is defined %}
-        <div class="card__media">  
+        <div class="card__media" aria-hidden="true">  
           {{ content.field_card_image }}
         </div>
       {% endif %}


### PR DESCRIPTION
- mark the media within clickable cards as aria-hidden 
- add back the hover effect for cards in "Featured Content"

We were planning to add a 'display alt text' field to the cards, but turns out it's not necessary.