### PR TITLE
chore: improve accessibility for press carousel

### DIFF
--- a/web/themes/interledger/css/components/cards.css
+++ b/web/themes/interledger/css/components/cards.css
@@ -370,6 +370,10 @@
   animation: scroll-left 18s linear infinite;
 }
 
+.press-logos .duplicate-logos {
+  display: flex;
+}
+
 .press-logos .card {
   padding: var(--space-s);
 }

--- a/web/themes/interledger/templates/views-view--logo-block.html.twig
+++ b/web/themes/interledger/templates/views-view--logo-block.html.twig
@@ -1,6 +1,8 @@
 <div class="press-carousel">
-  <div class="press-logos">
+  <div class="press-logos" aria-label="Press coverage logos">
     {{ rows }}
-    {{ rows }}
+    <div class="duplicate-logos" aria-hidden="true">
+      {{ rows }}
+    </div>
   </div>
 </div>


### PR DESCRIPTION
- aria-label the press-logos group
- hide from assistive technologies the duplicate logos used for creating the infinite carousel look