### PR TITLE
chore: update styles so soft hyphens are respected in Safari

### DIFF
--- a/web/themes/interledger/css/components/hero.css
+++ b/web/themes/interledger/css/components/hero.css
@@ -18,7 +18,7 @@
 
 @media screen and (max-width: 529px) {
   .hero h2 {
-    hyphens: auto;
+    hyphens: manual;
   }
 }
 

--- a/web/themes/interledger/interledger.libraries.yml
+++ b/web/themes/interledger/interledger.libraries.yml
@@ -1,5 +1,5 @@
 global-styling:
-  version: 1.4.4
+  version: 1.4.5
   css:
     theme:
       css/fonts.css: {}


### PR DESCRIPTION
## PR Checklist
- [ ] Linear [INTORG-7 ](https://linear.app/interledger/issue/INTORG-7/safari-not-respecting-soft-hyphens-in-our-banner-text) issue
- [ ] If styles were updated:
  - [ ] Stylesheet version has been bumped

## Summary
Safari wasn't respecting the soft hyphens in the banners
- updated styles
- updated content types in Drupal to add soft hyphens (Hero banner - Podcast & Hero banner - Get involved(video))

