### PR TITLE
chore: adjust banner header font-size for better mobile fit

### DIFF
--- a/web/themes/interledger/css/components/hero.css
+++ b/web/themes/interledger/css/components/hero.css
@@ -18,7 +18,12 @@
 
 @media screen and (max-width: 529px) {
   .hero h2 {
-    hyphens: auto;
+    hyphens: manual; 
+    font-size: var(--step-4)
+  }
+
+  .hero h2 span {
+    font-size: var(--step-4) !important;
   }
 }
 

--- a/web/themes/interledger/interledger.libraries.yml
+++ b/web/themes/interledger/interledger.libraries.yml
@@ -1,5 +1,5 @@
 global-styling:
-  version: 1.4.4
+  version: 1.4.5
   css:
     theme:
       css/fonts.css: {}


### PR DESCRIPTION
## PR Checklist
- [ ] [INTORG-45](https://linear.app/interledger/issue/INTORG-45/hacktoberfest-page-updates) Linear issue 
- [ ] If styles were updated:
  - [ ] Stylesheet version has been bumped

## Summary

- Make heading font smaller on mobile, so text can fit better
- Safari wasn't respecting the soft hyphens in the banners

  - updated styles
  - updated content types in Drupal to add/remove soft hyphens (Hero banner - Join the network, Hero banner - Get involved(video)) and to add zero-width no-break space (Hero banner - Open Standards)
 

Includes changes from[ PR 114](https://github.com/interledger/interledger.org-v4/pull/114) => closed PR