### PR TITLE
chore: set iframes inside articles to width: 100%

### DIFF
--- a/web/themes/interledger/css/components/article.css
+++ b/web/themes/interledger/css/components/article.css
@@ -130,11 +130,11 @@
 
 .news-article iframe {
   aspect-ratio: 16 / 9;
-  width: 600px;
+  width: 100%; 
   height: auto;
-  margin-inline: auto;
   display: block;
   margin-block-end: var(--space-s);
+  border-radius: var(--border-radius);
 }
 
 @media screen and (min-width: 800px) {

--- a/web/themes/interledger/interledger.libraries.yml
+++ b/web/themes/interledger/interledger.libraries.yml
@@ -1,5 +1,5 @@
 global-styling:
-  version: 1.4.6
+  version: 1.4.5
   css:
     theme:
       css/fonts.css: {}

--- a/web/themes/interledger/interledger.libraries.yml
+++ b/web/themes/interledger/interledger.libraries.yml
@@ -1,5 +1,5 @@
 global-styling:
-  version: 1.4.4
+  version: 1.4.6
   css:
     theme:
       css/fonts.css: {}


### PR DESCRIPTION
## PR Checklist
- [x] Linked issue added  - No existent issue 
- [x] If styles were updated:
  - [x] Stylesheet version has been bumped

## Summary
Set iframes (remote videos) inside articles to width: 100%
