### PR TITLE
Add Spanish label to Spanish Summit sessions

### DIFF
--- a/web/themes/interledger/css/components/summit-talk.css
+++ b/web/themes/interledger/css/components/summit-talk.css
@@ -82,7 +82,7 @@
 .talks-listing img {
   max-width: 8em;
   max-height: 8em;
-  width:200px;
+  width: 200px;
   height: 200px;
   border-radius: 50%;
   border: 2px solid var(--color-primary-fallback);
@@ -98,6 +98,18 @@
   margin-block-end: var(--space-2xs);
 }
 
+.talk__teaser p span.session-languages {
+  display: inline-block;
+  margin-right: 0.1rem;
+  padding: 0 0.375rem;
+  font-size: var(--step--2);
+  line-height: 1.5;
+  font-weight: bold;
+  background-color: #3f3f3f;
+  color: var(--color-white);
+  border-radius: 2px;
+}
+
 @media screen and (max-width: 799px) {
   .talk__info {
     flex-direction: column;
@@ -108,9 +120,9 @@
   }
 
   .talks-listing li {
-    flex-direction: column; 
-    align-items: center; 
-    gap: var(--space-xs); 
+    flex-direction: column;
+    align-items: center;
+    gap: var(--space-xs);
   }
 }
 

--- a/web/themes/interledger/templates/node--summit-talk-2025--teaser.html.twig
+++ b/web/themes/interledger/templates/node--summit-talk-2025--teaser.html.twig
@@ -18,5 +18,10 @@
     <time datetime="{{ startDate }}">{{ node.field_talk_start.0.value|date('U')|format_date('custom', 'D j M Y, H:i') }}</time><span> - {{ duration }}{{ 'min'|t }}</span>
     {{ videoIndicator|raw }}
   </p>
+  <p>
+    {% for language in node.field_session_languages %}
+      <span class="session-languages">{{ language.value }}</span>
+    {% endfor %}
+  </p>
   <p>{{ talkDescription|length > 400 ? talkDescription|slice(0, 400)|raw ~ '…' : talkDescription|raw }}</p>
 </div>


### PR DESCRIPTION
## PR Checklist
- [ ] Linked issue added (e.g., `Fixes #123`) - Linear issue [INTORG-63](https://linear.app/interledger/issue/INTORG-63/add-spanish-label-to-spanish-summit-sessions)
- [ ] If styles were updated:
  - [ ] Stylesheet version has been bumped

## Summary
Add Spanish label to Spanish Summit sessions on /talks page and /talk/[session]
- available languages are pulled from `node.field_session_languages` - the field does not exist on production yet, names will have to match! 