### PR TITLE
feat: create templates for Fellow ID pages and teaser view

### DIFF
--- a/web/themes/interledger/interledger.libraries.yml
+++ b/web/themes/interledger/interledger.libraries.yml
@@ -1,5 +1,5 @@
 global-styling:
-  version: 1.7.9
+  version: 1.7.10
   css:
     theme:
       css/fonts.css: {}

--- a/web/themes/interledger/templates/node--fellow--full.html.twig
+++ b/web/themes/interledger/templates/node--fellow--full.html.twig
@@ -1,0 +1,23 @@
+{% set mediaEntity = node.field_fellow_photo.entity %}
+{% set imageUri = mediaEntity.field_media_image.entity.uri.value %}
+{% if imageUri %}
+	{% set imageUrl = file_url(imageUri) %}
+{% endif %}
+{% set imageAlt = mediaEntity.field_media_image.alt %}
+
+<div class="speaker node--{{ node.id }}">
+	<header class="speaker__header">
+		<div class="content-wrapper speaker-wrapper">
+			<div class="speaker__text">
+				<h1>{{ node.field_fellow_name.0.value|raw }}</h1>
+				<p>{{ node.field_fellow_tagline.0.value|raw }}</p>
+			</div>
+			<div class="speaker__img">
+				<img src="{{ imageUrl }}" alt="{{ imageAlt }}" loading="lazy">
+			</div>
+		</div>
+	</header>
+	<div class="content-wrapper speaker__info text__body">
+		{{ node.field_fellow_bio.0.value |raw }}
+	</div>
+</div>

--- a/web/themes/interledger/templates/node--fellow--teaser.html.twig
+++ b/web/themes/interledger/templates/node--fellow--teaser.html.twig
@@ -1,0 +1,14 @@
+{% set mediaEntity = content.field_fellow_photo[0]['#entity'] %}
+{% set imageUri = mediaEntity.field_media_image.entity.uri.value %}
+{% if imageUri %}
+	{% set imageUrl = file_url(imageUri | image_style('thumbnail')) %}
+{% endif %}
+{% set imageAlt = mediaEntity.field_media_image.alt %}
+{% set nodeLink = path('entity.node.canonical', {'node': node.id}) %}
+{% set fellowUrl = node.field_fellow_external_link.value is not empty ? node.field_fellow_external_link.value : nodeLink %}
+
+<a href="{{ fellowUrl }}">
+	<img src="{{ imageUrl }}" alt="{{ imageAlt }}" height="240" width="240" loading="lazy">
+	<h2>{{ node.field_fellow_name.0.value|raw }}</h2>
+	<p>{{ node.field_fellow_quote.0.value|raw }}</p>
+</a>

--- a/web/themes/interledger/templates/views-view--fellows--block.html.twig
+++ b/web/themes/interledger/templates/views-view--fellows--block.html.twig
@@ -1,0 +1,3 @@
+<div class="content-wrapper talks-wrapper">
+	{{ rows }}
+</div>

--- a/web/themes/interledger/templates/views-view-unformatted--fellows--block.html.twig
+++ b/web/themes/interledger/templates/views-view-unformatted--fellows--block.html.twig
@@ -1,0 +1,7 @@
+<ul class="people-grid speakers-listing">
+	{% for row in rows %}
+		<li{{row.attributes.addClass(row_classes)}}>
+			{{- row.content -}}
+		</li>
+	{% endfor %}
+</ul>


### PR DESCRIPTION
## PR Checklist
- [X] Linked issue added (e.g., `Fixes #123`)
- [X] If styles were updated:
  - [X] Stylesheet version has been bumped

## Summary
Linear issue: Create the past fellows - INTORG-545[
](https://linear.app/interledger/issue/INTORG-545/create-the-past-fellows)

This PR adds Twig templates for the Past Fellows teaser list and individual fellow pages.

The templates reuse existing Summit Speakers styles for both the teaser and detail views, with one key difference: Past Fellow pages render in light mode instead of the dark mode used by Summit Speaker pages.