### PR TITLE
chore: remove underline from people grid paragraphs

### DIFF
--- a/web/themes/interledger/css/components/people.css
+++ b/web/themes/interledger/css/components/people.css
@@ -21,3 +21,12 @@
   margin-block-start: var(--space-3xs);
   margin-block-end: var(--space-2xs);
 }
+
+.people-grid a {
+  text-decoration: none;
+}
+
+.people-grid a:hover h2,
+.people-grid a:focus h2 {
+  text-decoration: underline;
+}

--- a/web/themes/interledger/interledger.libraries.yml
+++ b/web/themes/interledger/interledger.libraries.yml
@@ -1,5 +1,5 @@
 global-styling:
-  version: 1.7.11
+  version: 1.7.12
   css:
     theme:
       css/fonts.css: {}


### PR DESCRIPTION
## PR Checklist
- [ ] Linked issue added (e.g., `Fixes #123`)
- [x] If styles were updated:
  - [x] Stylesheet version has been bumped

## Summary
<!-- What has been updated and why -->
For the fellows grid having the paragraph underlined was overwhelming. So I left the underline only on the header for all people grid elements
