### PR TITLE
fix: rotated menu icons to face down by default

### DIFF
--- a/web/themes/interledger/css/navigation.css
+++ b/web/themes/interledger/css/navigation.css
@@ -34,6 +34,7 @@
   display: inline-block;
   width: 9px;
   margin-left: 0.5rem;
+  transform: translateY(30%) rotate(180deg);
   transition: transform 0.5s ease-in-out;
   @media(prefers-reduced-motion) {
     transition: transform 0s;
@@ -43,7 +44,7 @@
 .site-nav__links .has-submenu > a[aria-expanded="true"]::after,
 .site-nav__links .has-submenu > a:hover::after,
 .site-nav__links .has-submenu:has(a:hover) > a::after {
-  transform: translateY(30%) rotate(180deg);
+  transform: translateY(0%) rotate(0deg);
 }
 
 .site-nav__links a {

--- a/web/themes/interledger/interledger.libraries.yml
+++ b/web/themes/interledger/interledger.libraries.yml
@@ -1,5 +1,5 @@
 global-styling:
-  version: 1.7.3
+  version: 1.7.14
   css:
     theme:
       css/fonts.css: {}


### PR DESCRIPTION
## PR Checklist
- [x] Linked issue added (e.g., `Fixes #123`)
- [x] If styles were updated:
  - [x] Stylesheet version has been bumped

## Summary
<!-- What has been updated and why -->
Menu arrow icons were pointing the wrong direction on expand and collapse
Fixes  INTORG-548
