### PR TITLE
docs: updated documentation to reflect that we are now serving /developers from netlify

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,7 +11,7 @@ This is the Interledger Foundation website, a Drupal 10 CMS deployed on Google C
 - **Database**: Cloud SQL (MySQL) with separate databases for staging and production
 - **Load Balancer**: GCP External HTTPS Load Balancer (IP: 34.111.215.251)
 - **Files**: Stored locally on VM at `/var/www/{environment}/web/sites/default/files/`
-- **Static Portal**: Developers portal runs on Cloud Run (nginx serving Astro-built static site)
+- **Developers Portal**: Built and hosted by Netlify; a Cloud Run nginx service (`nginx-rewrite`) reverse-proxies `/developers/*` from the GCP load balancer to Netlify so the address bar stays on `interledger.org`
 
 ### Environment Configuration
 
@@ -178,7 +178,7 @@ sudo chmod -R 775 /var/www/production/web/sites/default/files/
 
 ### Backend Services
 - `drupal-sites-backend`: Serves both production and staging Drupal
-- `nginx-rewrite-backend`: Serves `/developers` portal (Cloud Run)
+- `nginx-rewrite-backend`: Cloud Run reverse-proxy forwarding `/developers/*` to Netlify (Cloud CDN enabled)
 - `umami-analytics-backend`: Serves Umami analytics (Cloud Run)
 
 ### Instance Groups

--- a/ci/deploy/README.md
+++ b/ci/deploy/README.md
@@ -159,46 +159,54 @@ The load balancer performs health checks on the GCE instance:
 
 ## The /developers Portal
 
-The developers portal (`https://interledger.org/developers` and `https://staging.interledger.org/developers`) is a static Astro site served via nginx on Cloud Run.
-
-**Note**: Unlike the main Drupal sites which run on the GCE VM, the developers portal continues to use Cloud Run for its static content delivery.
+The developers portal (`https://interledger.org/developers` and `https://staging.interledger.org/developers`) is an Astro/Starlight site built and hosted on **Netlify**, fronted by the GCP load balancer so the browser URL stays on `interledger.org`.
 
 ### Architecture
 
 1. **Source**: `interledger.org-developers` GitHub repository
-2. **Build**: Astro builds static site in GitHub Actions
-3. **Storage**: Synced to `gs://interledger-org-developers-portal/developers`
-4. **Container**: Multi-stage Docker build fetches content from GCS at build time
-5. **Serving**: nginx on Cloud Run serves baked-in static files
-6. **Caching**: Cloud CDN enabled (1hr TTL for HTML, 24hr max)
-7. **Routing**: Both production and staging `/developers` paths route to the same Cloud Run service
+2. **Build & hosting**: Netlify builds on push to `main` and serves at `https://interledger-org-developers.netlify.app/developers/`
+3. **Proxy**: A small nginx service on Cloud Run (`nginx-rewrite`) reverse-proxies `/developers/*` requests from the GCP load balancer to Netlify. The container holds no site content.
+4. **Caching**: Cloud CDN is enabled on `nginx-rewrite-backend` (default TTL 1hr, max 24hr). Netlify's own edge is effectively just an origin hop for the proxy.
+5. **Routing**: Both production and staging `/developers` paths route to the same Cloud Run service via `nginx-rewrite-backend`
 
 ### Deployment Flow
 
 ```
-GitHub Push to main
+GitHub Push to main (interledger.org-developers)
   ↓
-GitHub Actions (.github/workflows/deploy_gcs.yml)
+Netlify build & deploy
   ↓
-  1. Build Astro site (bun run build)
-  2. Sync to GCS bucket
-  3. Build nginx container (fetches from GCS)
-  4. Deploy to Cloud Run (nginx-rewrite service)
-  5. Invalidate CDN cache (/developers/*)
+https://interledger-org-developers.netlify.app/developers/
+  ↑
+  └── proxied live by ──
+      Cloud Run nginx (nginx-rewrite)
+  ↑
+  └── path-routed from ──
+      GCP Load Balancer /developers/*
   ↓
 interledger.org/developers
 staging.interledger.org/developers
 ```
 
+The `nginx-rewrite` container itself is rebuilt only when `ci/nginx-rewrite/**` changes (via the `Deploy nginx proxy to Cloud Run` workflow in the developers repo). Content changes do **not** require a container rebuild.
+
+### CDN cache after a Netlify deploy
+
+Because Cloud CDN caches `/developers/*`, content changes on Netlify can take up to 1 hour to appear on `interledger.org/developers/`. To force an immediate refresh, run the **Invalidate CDN** workflow in the `interledger.org-developers` repo, or run:
+
+```bash
+gcloud compute url-maps invalidate-cdn-cache interledger-org --path "/developers/*" --async
+```
+
 ### Nginx Configuration
 
-Simple configuration using standard nginx patterns:
-- **Root**: `/usr/share/nginx/html` (contains `developers/` folder)
-- **try_files**: `$uri $uri/ $uri/index.html =404` for pretty URLs
-- **Redirects**: `/developers` → `/developers/` (301)
-- **absolute_redirect off**: Ensures relative redirects for load balancer compatibility
+Thin reverse proxy:
+- **`location /developers/`**: `proxy_pass` to `https://interledger-org-developers.netlify.app` with Host header override and `proxy_ssl_server_name on`
+- **`location = /developers`**: 301 → `/developers/`
+- **`absolute_redirect off`**: keep redirects relative so the public hostname/scheme survives the proxy hop
+- **`proxy_redirect`**: rewrite absolute Netlify URLs in `Location` headers back to relative paths
 
-See `interledger.org-developers/ci/nginx-rewrite/` for nginx config and Dockerfile.
+See `interledger.org-developers/ci/nginx-rewrite/` for the nginx config and Dockerfile.
 
 ## Common Operations
 

--- a/ci/deploy/README.md
+++ b/ci/deploy/README.md
@@ -166,7 +166,7 @@ The developers portal (`https://interledger.org/developers` and `https://staging
 1. **Source**: `interledger.org-developers` GitHub repository
 2. **Build & hosting**: Netlify builds on push to `main` and serves at `https://interledger-org-developers.netlify.app/developers/`
 3. **Proxy**: A small nginx service on Cloud Run (`nginx-rewrite`) reverse-proxies `/developers/*` requests from the GCP load balancer to Netlify. The container holds no site content.
-4. **Caching**: Cloud CDN is enabled on `nginx-rewrite-backend` (default TTL 1hr, max 24hr). Netlify's own edge is effectively just an origin hop for the proxy.
+4. **Caching**: Cloud CDN is enabled on `nginx-rewrite-backend`. In normal operation, updated `/developers` content usually appears within about 1 hour because the default CDN TTL is 1 hour, but cached responses may persist longer depending on cache headers, up to the configured 24-hour maximum TTL. Netlify's own edge is effectively just an origin hop for the proxy.
 5. **Routing**: Both production and staging `/developers` paths route to the same Cloud Run service via `nginx-rewrite-backend`
 
 ### Deployment Flow


### PR DESCRIPTION
This pull request updates the documentation to reflect a major change in how the developers portal (`/developers`) is built and served. The portal is now built and hosted on Netlify, with a Cloud Run nginx service acting as a reverse proxy from the GCP load balancer to Netlify. The documentation has been revised to describe this new architecture, deployment flow, and CDN caching behavior.

**Developers Portal Architecture & Hosting:**

* Updated all references to the developers portal to indicate it is now built and hosted on Netlify, replacing the previous Cloud Run/nginx static serving model. The Cloud Run service (`nginx-rewrite`) now acts solely as a reverse proxy from the GCP load balancer to Netlify, ensuring URLs remain on `interledger.org`. [[1]](diffhunk://#diff-227c2c26cb2ee0ce0f46a320fc48fbcbdf21801a57f59161b1d0861e8aad55f5L14-R14) [[2]](diffhunk://#diff-e7e2e40b11ca1c47de9f8aae0908ee88fbdd3b5d064e65356f42a7d0bc8edc4bL162-R209)
* Clarified that the `nginx-rewrite-backend` service is now a proxy to Netlify with Cloud CDN enabled, rather than serving site content directly.

**Deployment Flow & Operations:**

* Updated deployment instructions: Netlify now handles builds and hosting on pushes to `main`, and the nginx proxy container is rebuilt only when its configuration changes. Provided instructions for invalidating the Cloud CDN cache after Netlify deploys to ensure timely content updates.

**Nginx Proxy Configuration:**

* Revised nginx configuration section to describe the new reverse proxy setup, including how redirects and headers are managed to maintain correct URL behavior through the proxy.